### PR TITLE
Update gst module to use the latest glib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/greenkeytech/gst
 
-require github.com/greenkeytech/glib v0.0.0-20180917160106-84fff29e4d75
+require github.com/greenkeytech/glib v0.0.0-20181116213058-bf286fc1f3b9

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/greenkeytech/glib v0.0.0-20180917160106-84fff29e4d75 h1:stNWUmnBC2C7gSuRVPr3KiKNzpYWeBh0OfbhmFAvjZU=
-github.com/greenkeytech/glib v0.0.0-20180917160106-84fff29e4d75/go.mod h1:46ebIkl/4v7kwQiYNvnsU0p+XhmpQ3FP7Qd+zokshGY=
+github.com/greenkeytech/glib v0.0.0-20181116213058-bf286fc1f3b9 h1:p2JjOkDl7kpRU6BGm3AW6R1TyoLy/15ZfqLAxI5eIBs=
+github.com/greenkeytech/glib v0.0.0-20181116213058-bf286fc1f3b9/go.mod h1:46ebIkl/4v7kwQiYNvnsU0p+XhmpQ3FP7Qd+zokshGY=


### PR DESCRIPTION
Now that we're using go modules the `gst` `go.mod` and `go.sum` need to reference the correct version of our `glib` package.  Before we started using modules in our builds this didn't matter but now it does.