### PR TITLE
Update go.mod to current version of glib module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/greenkeytech/gst
 
-require github.com/greenkeytech/glib v0.0.0-20181116213058-bf286fc1f3b9
+require github.com/greenkeytech/glib v0.0.0-20200227134114-0f39926ed130
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/greenkeytech/glib v0.0.0-20181116213058-bf286fc1f3b9 h1:p2JjOkDl7kpRU6BGm3AW6R1TyoLy/15ZfqLAxI5eIBs=
 github.com/greenkeytech/glib v0.0.0-20181116213058-bf286fc1f3b9/go.mod h1:46ebIkl/4v7kwQiYNvnsU0p+XhmpQ3FP7Qd+zokshGY=
+github.com/greenkeytech/glib v0.0.0-20200227134114-0f39926ed130 h1:YmE+zc7Agp9gXGxjbPmjEN7lK1f4noiaGhXN3asg0LA=
+github.com/greenkeytech/glib v0.0.0-20200227134114-0f39926ed130/go.mod h1:PeE7lRP5h2Z6e6jegwI1ifwyQjRIeWeVESga0NTu5CQ=


### PR DESCRIPTION
Updates gst to use the newest version of the glib module that includes the GetAllPropertyNames method.